### PR TITLE
Update behavior of union type.

### DIFF
--- a/examples/tests/interop.test.ts
+++ b/examples/tests/interop.test.ts
@@ -57,3 +57,19 @@ test('interop can hold the value of the field', () => {
   expect(interop.interopName).toBe('a');
   expect(interop.interopControl).toBe(result.current.form.control);
 });
+
+test('interop can hold the union value of the field', () => {
+  const { result } = renderHook(() => {
+    const form = useForm<{ a: string | number }>();
+    const lens = useLens({ control: form.control });
+    const ctrl = useController(lens.focus('a').interop());
+    return { lens, form, ctrl };
+  });
+
+  const interop = result.current.lens.focus('a').interop((interopControl, interopName) => ({ interopName, interopControl }));
+
+  expectTypeOf(result.current.ctrl.field.value).toEqualTypeOf<string | number>();
+
+  expect(interop.interopName).toBe('a');
+  expect(interop.interopControl).toBe(result.current.form.control);
+});

--- a/examples/tests/interop.test.ts
+++ b/examples/tests/interop.test.ts
@@ -73,3 +73,19 @@ test('interop can hold the union value of the field', () => {
   expect(interop.interopName).toBe('a');
   expect(interop.interopControl).toBe(result.current.form.control);
 });
+
+test('interop can hold the literal union value of the field', () => {
+  const { result } = renderHook(() => {
+    const form = useForm<{ type: 'admin' | 'general' }>();
+    const lens = useLens({ control: form.control });
+    const ctrl = useController(lens.focus('type').interop());
+    return { lens, form, ctrl };
+  });
+
+  const interop = result.current.lens.focus('type').interop((interopControl, interopName) => ({ interopName, interopControl }));
+
+  expectTypeOf(result.current.ctrl.field.value).toEqualTypeOf<'admin' | 'general'>();
+
+  expect(interop.interopName).toBe('type');
+  expect(interop.interopControl).toBe(result.current.form.control);
+});

--- a/src/LensCore.ts
+++ b/src/LensCore.ts
@@ -5,7 +5,7 @@ import type { Lens } from './types/lenses';
 import type { LensesCache } from './utils';
 
 interface Settings {
-  lensesMap?: LensesDeepMap | undefined;
+  lensesMap?: LensesDeepMap<unknown> | undefined;
   propPath?: string | undefined;
 }
 
@@ -55,7 +55,7 @@ export class LensCore {
     return focusedLens;
   }
 
-  public reflect(getter: (original: LensCore) => LensesMap): LensCore {
+  public reflect(getter: (original: LensCore) => LensesMap<unknown>): LensCore {
     const fromCache = this.cache.complex.get(getter);
 
     if (fromCache) {
@@ -70,7 +70,7 @@ export class LensCore {
     return newLens;
   }
 
-  public join(another: LensCore, merger: (original: LensCore, another: LensCore) => LensesMap): LensCore {
+  public join(another: LensCore, merger: (original: LensCore, another: LensCore) => LensesMap<unknown>): LensCore {
     const fromCache = this.cache.complex.get(merger);
 
     if (fromCache) {

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -1,11 +1,11 @@
 import type { Lens, NonObjectFieldShim } from './lenses';
 
-export type LensesMap = {
-  [key: string]: Lens<[] | object | string | number | boolean | undefined | null>;
+export type LensesMap<T> = {
+  [key in keyof T]: Lens<T[key]>;
 };
 
-export type LensesDeepMap = {
-  [key: string]: Lens<[] | object | string | number | boolean | undefined | null> | LensesDeepMap;
+export type LensesDeepMap<T> = {
+  [key: string]: Lens<T> | LensesDeepMap<T>;
 };
 
 export type UnwrapLens<T> =

--- a/src/types/lenses.ts
+++ b/src/types/lenses.ts
@@ -85,9 +85,7 @@ export interface HookFormInterop<T extends FieldValues, Name> {
 }
 
 export interface LensInterop<T> {
-  interop: T extends FieldValues
-    ? HookFormInterop<NonObjectFieldShim<T>, ShimKeyName>
-    : HookFormInterop<NonObjectFieldShim<T>, ShimKeyName>;
+  interop: HookFormInterop<NonObjectFieldShim<T>, ShimKeyName>;
 }
 
 export interface LensFocus<T> {
@@ -169,7 +167,7 @@ export interface LensReflect<T> {
    * }
    * ```
    */
-  reflect: <T2 extends LensesMap>(getter: (original: Lens<T>) => T2) => Lens<UnwrapLens<T2>>;
+  reflect: <T2>(getter: (original: Lens<T>) => LensesMap<T2>) => Lens<UnwrapLens<LensesMap<T2>>>;
 }
 
 export interface LensJoin<T> {
@@ -219,7 +217,7 @@ export interface LensJoin<T> {
    * }
    * ```
    */
-  join: <T2, R extends LensesMap>(another: T2, merger: (original: Lens<T>, another: T2) => R) => Lens<UnwrapLens<R>>;
+  join: <T2, R>(another: T2, merger: (original: Lens<T>, another: T2) => LensesMap<R>) => Lens<UnwrapLens<LensesMap<R>>>;
 }
 
 export interface LensMap<T extends any[]> {


### PR DESCRIPTION
# Motivation

Sometimes, we want to use a literal union type with react-hook-form.

Imagine a user form with a radio button to select the user type.

```typescript
const form = useForm<{ type: 'admin' | 'general' }>();
```

Then, I tried to use with a lens:

```typescript
const lens = useLens({ control: form.control });
const ctrl = useController(lens.focus('type').interop()); // Error.
```

The return type of `interop()` is inferred as follows.

```typescript
{ name: '__DO_NOT_USE_NON_OBJECT_FIELD_SHIM__'   control: Control<NonObjectFieldShim<'admin'>> } |
{ name: '__DO_NOT_USE_NON_OBJECT_FIELD_SHIM__'   control: Control<NonObjectFieldShim<'general'>> }
```

I expected:
```typescript
{ name: '__DO_NOT_USE_NON_OBJECT_FIELD_SHIM__'   control: Control<NonObjectFieldShim<'admin' | 'general'>> }
```

# Solution

`LensInterop` uses `T extends FieldValues`, which causes the union type to distribute.  I removed the condition.

Then, I also needed to make LensesMap generic.

I suspect that `Control<T>` which is imported from react-hook-form and used in `Lens<T>`, involves some contravariant types. The distribution behavior was necessary because the original `LensesMap` accepted a broad type, `[] | object | string | number | boolean | undefined | null`.

Here’s a small reproduction of the code:

https://www.typescriptlang.org/play/?#code/PTAEEYDpQSVAHATgU3gQxQEwQZ2QV0wHsBaAFwE95lQiAzUAG2QDs8cAaUAI3zNBIA+UACYAUCAlhK1UAGEiLMoiKMAPABVhAXlABvKaCMs0AW2QAuUBoDcho4rmMAlgGMA1lYAUANzSMrDQBKUG1hHyJnTEMAXzFDZAAPeCJEfmclZEQ6NFcaAAkiIncAMVTTGEyVeE1hAxAjUC8gqz1QV0VlVSsFJRV1LVAYuwa4hOTU9KqcvNAAGVYcSrIsohrB+rAjDJXqq0LissQKqrXakbAxhpkaBbZa0PnF5dX1wTtDEWgNAAtnHFAN1A-1ArCI+AA5j9QHRUqAUEgiJh8K4MhDIGIgXccA9dAZjGZLNY7EYGh1TOYlLQ+LQWE43O4mBkaGQiAg0DgATdXD9kB4MQ46S4PN4-AFrCEwqAIlE7GMsYtkDgALJoeCPfGgADa7mQFCsOGUaIAulZsWotcbQAAfWjcABWfP4tsNiDRNtALHwpm4WQ93CKzDQLA9+BYmGQdGZ2FtXsYjHeYmG8QjrkYGBodDDrjIzkU8MjzBzmhEoMSK3DAOxStV8EEXghyDIu28kuEGhELWs4jEqfTKCYTdAiQADFYw+4WEQAO4seLMfhocCPFB0ItkLzNUJ1MRGFBkfCIEOagnmKyj0Acp73V1owQcXdDOVBIA