### PR TITLE
feat: remove lens from cache on control unregister

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ function App() {
   const { control } = useForm<{ firstName: string; lastName: string }>();
 
   const lens = useMemo(() => {
-    const cache = new LensesStorage();
+    const cache = new LensesStorage(control);
     return LensCore.create(control, cache);
   }, [control]);
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ import { useFieldArray } from '@hookform/lenses/rhf';
 function ContactsList({ lens }: { lens: Lens<Contact[]> }) {
   const { fields } = useFieldArray(lens.interop());
 
-  return lens.map(fields, (l, key) => <ContactForm key={key} lens={l} />);
+  return lens.map(fields, (value, l) => <ContactForm key={value.id} lens={l} />);
 }
 ```
 

--- a/examples/stories/hook-form/Unregister.story.tsx
+++ b/examples/stories/hook-form/Unregister.story.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { Path, SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
+import { Lens, useLens } from '@hookform/lenses';
+import { action } from '@storybook/addon-actions';
+import type { Meta } from '@storybook/react';
+
+import { NumberInput, StringInput } from '../components';
+
+export default {
+  title: 'Hook Form',
+} satisfies Meta;
+
+export interface UnregisterFormData {
+  username: string;
+  age: number;
+  deep: {
+    nested: {
+      value: string;
+    };
+    another: string;
+  };
+  children: {
+    name: string;
+    surname: string;
+  }[];
+}
+
+export interface UnregisterProps {
+  onSubmit: SubmitHandler<UnregisterFormData>;
+}
+
+export function Unregister({ onSubmit = action('submit') }: UnregisterProps) {
+  const [hidden, setHidden] = useState(() => new Set<Path<UnregisterFormData> | 'form'>());
+  const { handleSubmit, control } = useForm<UnregisterFormData>({});
+  const lens = useLens({ control });
+
+  const toggleHidden = (path: Path<UnregisterFormData> | 'form') => {
+    setHidden((prev) => prev.symmetricDifference(new Set([path])));
+  };
+
+  const formToggleButton = (
+    <button type="button" onClick={() => toggleHidden('form')}>
+      Toggle whole form
+    </button>
+  );
+
+  if (hidden.has('form')) {
+    return formToggleButton;
+  }
+
+  return (
+    <>
+      {formToggleButton}
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div>
+          <button type="button" onClick={() => toggleHidden('username')}>
+            Toggle
+          </button>
+          {!hidden.has('username') && <StringInput lens={lens.focus('username')} label="username" shouldUnregister />}
+        </div>
+
+        <div>
+          <button type="button" onClick={() => toggleHidden('age')}>
+            Toggle
+          </button>
+          {!hidden.has('age') && <NumberInput lens={lens.focus('age')} label="age" shouldUnregister />}
+        </div>
+
+        <div>
+          <button type="button" onClick={() => toggleHidden('deep.nested.value')}>
+            Toggle
+          </button>
+          {!hidden.has('deep.nested.value') && (
+            <StringInput lens={lens.focus('deep').focus('nested').focus('value')} label="nested.value" shouldUnregister />
+          )}
+        </div>
+
+        <div>
+          <button type="button" onClick={() => toggleHidden('deep.another')}>
+            Toggle
+          </button>
+          {!hidden.has('deep.another') && <StringInput lens={lens.focus('deep.another')} label="another" shouldUnregister />}
+        </div>
+
+        <div>
+          <button type="button" onClick={() => toggleHidden('children')}>
+            Toggle
+          </button>
+          {!hidden.has('children') && <ChildForm lens={lens.focus('children')} />}
+        </div>
+
+        <div>
+          <button type="submit">submit</button>
+        </div>
+      </form>
+    </>
+  );
+}
+
+function ChildForm({ lens }: { lens: Lens<{ name: string; surname: string }[]> }) {
+  const { fields, append, remove } = useFieldArray({ ...lens.interop(), shouldUnregister: true });
+
+  return (
+    <div>
+      <button type="button" onClick={() => append({ name: '', surname: '' })}>
+        Add child
+      </button>
+      {lens.map(fields, (value, l, index) => (
+        <PersonForm key={value.id} lens={l} onRemove={() => remove(index)} />
+      ))}
+    </div>
+  );
+}
+
+function PersonForm({ lens, onRemove }: { lens: Lens<{ name: string; surname: string }>; onRemove: () => void }) {
+  return (
+    <div>
+      <StringInput lens={lens.focus('name')} label="name" shouldUnregister />
+      <StringInput lens={lens.focus('surname')} label="surname" shouldUnregister />
+      <button type="button" onClick={onRemove}>
+        Remove
+      </button>
+    </div>
+  );
+}

--- a/src/LensesStorage.ts
+++ b/src/LensesStorage.ts
@@ -1,3 +1,5 @@
+import type { Control, FieldValues } from 'react-hook-form';
+
 import type { LensCore } from './LensCore';
 
 export type LensesStorageComplexKey = (...args: any[]) => any;
@@ -9,11 +11,19 @@ export interface LensesStorageValue {
 
 export type LensCache = Map<string, LensesStorageValue>;
 
-export class LensesStorage {
+export class LensesStorage<TFieldValues extends FieldValues = FieldValues> {
   private cache: LensCache;
 
-  constructor() {
+  constructor(control: Control<TFieldValues>) {
     this.cache = new Map();
+
+    control?._subjects?.values?.subscribe?.({
+      next: () => {
+        control._names.unMount.forEach((name) => {
+          this.delete(name);
+        });
+      },
+    });
   }
 
   public get(propPath: string, complexKey?: LensesStorageComplexKey): LensCore | undefined {

--- a/src/useLens.ts
+++ b/src/useLens.ts
@@ -28,7 +28,7 @@ export function useLens<TFieldValues extends FieldValues = FieldValues>(
   deps: DependencyList = [],
 ): Lens<TFieldValues> {
   return useMemo(() => {
-    const cache = new LensesStorage();
+    const cache = new LensesStorage(props.control);
     const lens = LensCore.create<TFieldValues>(props.control, cache);
 
     return lens;


### PR DESCRIPTION
To detect that control is unregistered I subscribe for updates `control?._subjects?.values?.subscribe?`. But not sure if it the best solution.