### PR TITLE
Suggestion: useWatchLens

### DIFF
--- a/examples/tests/watch.test.ts
+++ b/examples/tests/watch.test.ts
@@ -1,0 +1,60 @@
+import { useForm, useWatch } from 'react-hook-form';
+import { useLens } from '@hookform/lenses';
+import { renderHook } from '@testing-library/react';
+
+import { useWatchLens } from '../../src/useWatchLens';
+
+test('watch: can get values', () => {
+  const { result } = renderHook(() => {
+    const form = useForm<{ a: string }>({
+      defaultValues: {
+        a: 'test_a',
+      },
+    });
+    const lens = useLens({ control: form.control });
+    const watch = useWatchLens(lens);
+    const rhfWatch = useWatch({
+      control: lens.interop().control,
+    });
+    return { lens, form, watch, rhfWatch };
+  });
+
+  const watch = result.current.watch;
+  expect(watch.a).toBe('test_a');
+  // @ts-expect-error
+  expect(result.current.rhfWatch.a).toBe('test_a');
+});
+
+test('watch: can get values only for focusing values', () => {
+  const { result } = renderHook(() => {
+    const form = useForm<{
+      name: { first: string; last: string };
+      introduction: {
+        message: string;
+      };
+    }>({
+      defaultValues: {
+        name: {
+          first: 'A',
+          last: 'B',
+        },
+        introduction: {
+          message: 'Hello',
+        },
+      },
+    });
+    const lens = useLens({ control: form.control });
+    const watch = useWatchLens(lens.focus('introduction'));
+    const rhfWatch = useWatch({
+      control: lens.interop().control,
+    });
+    return { lens, form, watch, rhfWatch };
+  });
+
+  const watch = result.current.watch;
+  expect(watch.message).toBe('Hello');
+  // @ts-expect-error
+  expect(watch.first).toBeUndefined();
+  // @ts-expect-error
+  expect(result.current.rhfWatch.introduction.message).toBe('Hello');
+});

--- a/examples/tests/watch.test.ts
+++ b/examples/tests/watch.test.ts
@@ -61,3 +61,36 @@ test('watch: can get values only for focusing values', () => {
   // @ts-expect-error
   expect(result.current.rhfWatch.introduction.message).toBe('Hello');
 });
+
+test('watch: can get values only for multiple focusing values', () => {
+  const { result } = renderHook(() => {
+    const form = useForm<{
+      introduction: {
+        message: string;
+        hobby: {
+          name: string;
+        };
+      };
+    }>({
+      defaultValues: {
+        introduction: {
+          message: 'Hello',
+          hobby: {
+            name: 'Baseball',
+          },
+        },
+      },
+    });
+    const lens = useLens({ control: form.control });
+    const watch = useWatchLens(lens.focus('introduction.hobby'));
+    const rhfWatch = useWatch({
+      control: lens.interop().control,
+    });
+    return { lens, form, watch, rhfWatch };
+  });
+
+  expect(result.current.watch.name).toBe('Baseball');
+  expect(result.current.rhfWatch.__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__?.introduction?.hobby?.name).toBeUndefined();
+  // @ts-expect-error
+  expect(result.current.rhfWatch.introduction.message).toBe('Hello');
+});

--- a/examples/tests/watch.test.ts
+++ b/examples/tests/watch.test.ts
@@ -1,8 +1,8 @@
-import { useForm, useWatch } from 'react-hook-form';
+import { useForm, useWatch as useWatchRhf } from 'react-hook-form';
 import { useLens } from '@hookform/lenses';
 import { renderHook } from '@testing-library/react';
 
-import { useWatchLens } from '../../src/useWatchLens';
+import { useWatch } from '../../src/rhf/useWatch';
 
 test('watch: can get values', () => {
   const { result } = renderHook(() => {
@@ -12,18 +12,14 @@ test('watch: can get values', () => {
       },
     });
     const lens = useLens({ control: form.control });
-    const watch = useWatchLens(lens);
-    const rhfWatch = useWatch({
-      control: lens.interop().control,
-    });
+    const watch = useWatch(lens.interop());
+    const rhfWatch = useWatchRhf(lens.interop());
     return { lens, form, watch, rhfWatch };
   });
 
-  const watch = result.current.watch;
-  expect(watch.a).toBe('test_a');
-  expect(result.current.rhfWatch.__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__?.a).toBeUndefined();
-  // @ts-expect-error
-  expect(result.current.rhfWatch.a).toBe('test_a');
+  expect(result.current.watch.a).toBe('test_a');
+  // FIXME?: non-focused lens becomes undefined with useWatch in react-hook-form.
+  expect(result.current.rhfWatch).toBeUndefined();
 });
 
 test('watch: can get values only for focusing values', () => {
@@ -45,21 +41,18 @@ test('watch: can get values only for focusing values', () => {
       },
     });
     const lens = useLens({ control: form.control });
-    const watch = useWatchLens(lens.focus('introduction'));
-    const rhfWatch = useWatch({
-      control: lens.interop().control,
-    });
+    const watch = useWatch(lens.focus('introduction').interop());
+    const rhfWatch = useWatchRhf(lens.focus('introduction').interop());
     return { lens, form, watch, rhfWatch };
   });
 
-  const watch = result.current.watch;
-  expect(watch.message).toBe('Hello');
+  expect(result.current.watch.message).toBe('Hello');
   // @ts-expect-error
-  expect(watch.first).toBeUndefined();
+  expect(result.current.watch.first).toBeUndefined();
 
-  expect(result.current.rhfWatch.__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__?.introduction?.message).toBeUndefined();
+  expect(result.current.rhfWatch.__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__?.message).toBeUndefined();
   // @ts-expect-error
-  expect(result.current.rhfWatch.introduction.message).toBe('Hello');
+  expect(result.current.rhfWatch.message).toBe('Hello');
 });
 
 test('watch: can get values only for multiple focusing values', () => {
@@ -82,15 +75,13 @@ test('watch: can get values only for multiple focusing values', () => {
       },
     });
     const lens = useLens({ control: form.control });
-    const watch = useWatchLens(lens.focus('introduction.hobby'));
-    const rhfWatch = useWatch({
-      control: lens.interop().control,
-    });
+    const watch = useWatch(lens.focus('introduction.hobby').interop());
+    const rhfWatch = useWatchRhf(lens.focus('introduction.hobby').interop());
     return { lens, form, watch, rhfWatch };
   });
 
   expect(result.current.watch.name).toBe('Baseball');
-  expect(result.current.rhfWatch.__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__?.introduction?.hobby?.name).toBeUndefined();
+  expect(result.current.rhfWatch.__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__?.name).toBeUndefined();
   // @ts-expect-error
-  expect(result.current.rhfWatch.introduction.message).toBe('Hello');
+  expect(result.current.rhfWatch.name).toBe('Baseball');
 });

--- a/examples/tests/watch.test.ts
+++ b/examples/tests/watch.test.ts
@@ -21,6 +21,7 @@ test('watch: can get values', () => {
 
   const watch = result.current.watch;
   expect(watch.a).toBe('test_a');
+  expect(result.current.rhfWatch.__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__?.a).toBeUndefined();
   // @ts-expect-error
   expect(result.current.rhfWatch.a).toBe('test_a');
 });
@@ -55,6 +56,8 @@ test('watch: can get values only for focusing values', () => {
   expect(watch.message).toBe('Hello');
   // @ts-expect-error
   expect(watch.first).toBeUndefined();
+
+  expect(result.current.rhfWatch.__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__?.introduction?.message).toBeUndefined();
   // @ts-expect-error
   expect(result.current.rhfWatch.introduction.message).toBe('Hello');
 });

--- a/src/rhf/useWatch.ts
+++ b/src/rhf/useWatch.ts
@@ -1,13 +1,11 @@
-import { type FieldValues, useWatch } from 'react-hook-form';
-
-import type { Lens } from './types';
+import { type Control, type FieldValues, useWatch as useWatchRhf } from 'react-hook-form';
 
 /**
  * Watch lens.
  *
  * @example
  * ```tsx
- * import { useWatchLens } from './useWatchLens';
+ * import { useWatch } from './useWatch';
  * import type { Lens } from './types';
  *
  * export type FormValues = {
@@ -19,7 +17,7 @@ import type { Lens } from './types';
  * };
  *
  * export function CountableTextArea({ lens }: Props) {
- *   const formValues = useWatchLens(lens);
+ *   const formValues = useWatch(lens);
  *   const { name, control } = lens.interop();
  *
  *   return (
@@ -31,12 +29,15 @@ import type { Lens } from './types';
  * }
  * ```
  */
-export function useWatchLens<TFieldValues extends FieldValues = FieldValues>(lens: Lens<TFieldValues>): TFieldValues {
-  const { control, name } = lens.interop();
-  return useWatch({
+export function useWatch<TFieldValues extends FieldValues = FieldValues>(props: {
+  name: '__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__';
+  control: Control<TFieldValues>;
+}): TFieldValues['__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__'] {
+  const { control, name } = props;
+  return useWatchRhf({
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     name: name ? name : undefined,
     control,
-  }) as TFieldValues;
+  }) as TFieldValues['__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__'];
 }

--- a/src/rhf/useWatch.ts
+++ b/src/rhf/useWatch.ts
@@ -17,8 +17,8 @@ import { type Control, type FieldValues, useWatch as useWatchRhf } from 'react-h
  * };
  *
  * export function CountableTextArea({ lens }: Props) {
- *   const formValues = useWatch(lens);
  *   const { name, control } = lens.interop();
+ *   const formValues = useWatch({ name, control });
  *
  *   return (
  *     <div>

--- a/src/useWatchLens.ts
+++ b/src/useWatchLens.ts
@@ -1,0 +1,41 @@
+import { type FieldValues, useWatch } from 'react-hook-form';
+
+import type { Lens } from './types';
+
+/**
+ * Watch lens.
+ *
+ * @example
+ * ```tsx
+ * import { useWatchLens } from './useWatchLens';
+ * import type { Lens } from './types';
+ *
+ * export type FormValues = {
+ *   message: string;
+ * };
+ *
+ * type Props = {
+ *   lens: Lens<FormValues>;
+ * };
+ *
+ * export function CountableTextArea({ lens }: Props) {
+ *   const formValues = useWatchLens(lens);
+ *   const { name, control } = lens.interop();
+ *
+ *   return (
+ *     <div>
+ *       <input {...control.register(name)} />
+ *       <p>Word Count: {formValues.message.length}</p>
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useWatchLens<TFieldValues extends FieldValues = FieldValues>(lens: Lens<TFieldValues>): TFieldValues {
+  const { control, name } = lens.interop();
+  const data = useWatch({
+    control,
+  }) as TFieldValues;
+
+  return name ? data[name] : data;
+}

--- a/src/useWatchLens.ts
+++ b/src/useWatchLens.ts
@@ -33,9 +33,10 @@ import type { Lens } from './types';
  */
 export function useWatchLens<TFieldValues extends FieldValues = FieldValues>(lens: Lens<TFieldValues>): TFieldValues {
   const { control, name } = lens.interop();
-  const data = useWatch({
+  return useWatch({
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    name: name ? name : undefined,
     control,
   }) as TFieldValues;
-
-  return name ? data[name] : data;
 }


### PR DESCRIPTION
### Motivation

Sometimes I want access to the current form value in order to enrich the form UI. For example, I might want to display a word count next to a text area.

I can use lens with useWatch from react-hook-form, but the type becomes something like `{__DO_NOT_USE_HOOK_FORM_CONTROL_SHIM__: ~~~~~~}`. This results in a loss of type safety and readability.

### Suggestion: Add `useWatchLens` Hook

```tsx
import { useWatchLens } from './useWatchLens';
import type { Lens } from './types';

type FormValues = {
  message: string;
};

type Props = {
  lens: Lens<FormValues>;
};

function CountableTextArea({ lens }: Props) {
  const formValues = useWatchLens(lens);
  const { name, control } = lens.interop();

  return (
    <div>
      <input {...control.register(name)} />
      <p>Word Count: {formValues.message.length}</p>
    </div>
  );
}
```