### PR TITLE
fix: don't use cache when override

### DIFF
--- a/src/LensCore.ts
+++ b/src/LensCore.ts
@@ -39,12 +39,6 @@ export class LensCore<T extends FieldValues> {
     const propString = prop.toString();
     const nestedPath = this.path ? `${this.path}.${propString}` : propString;
 
-    const fromCache = this.cache?.get(nestedPath);
-
-    if (fromCache) {
-      return fromCache;
-    }
-
     if (Array.isArray(this.override)) {
       const [template] = this.override;
       const result = new LensCore(this.control, nestedPath, this.cache);
@@ -72,6 +66,12 @@ export class LensCore<T extends FieldValues> {
         this.cache?.set(overriddenLens, nestedPath);
         return overriddenLens;
       }
+    }
+
+    const fromCache = this.cache?.get(nestedPath);
+
+    if (fromCache) {
+      return fromCache;
     }
 
     const result = new LensCore(this.control, nestedPath, this.cache);

--- a/tests/object-interop.test.ts
+++ b/tests/object-interop.test.ts
@@ -90,3 +90,17 @@ test('interop can hold the literal union value of the field', () => {
   expect(interop.interopName).toBe('type');
   expect(interop.interopControl).toBe(result.current.form.control);
 });
+
+test('interop return non cached name when override', () => {
+  const { result } = renderHook(() => {
+    const form = useForm<{ a: string; b: number }>();
+    const lens = useLens({ control: form.control });
+    const reflect = lens.reflect((l) => ({ a: l.b }));
+
+    // cache a
+    lens.focus('a');
+    return reflect;
+  });
+
+  expect(result.current.focus('a').interop().name).toEqual('b');
+});


### PR DESCRIPTION
`focus` use the cache when we override the name with `reflect`

```tsx
const form = useForm<{ name: string; otherName: string }>();
const lens = useLens({ control: form.control });
const reflect = lens.reflect((l) => ({ name: l.otherName }));

// Cache name
lens.focus('name');

console.log(reflect.focus('name').interop().name) // print name, should be otherName
```

When override, `focus` never use the cache, I don't know if the behavior is wanted.