### PR TITLE
Support react-hook-form v7.55

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19",
-        "react-hook-form": ">=7.55.0 <8.0.0",
+        "react-hook-form": "^7.55.0",
       },
     },
   },
@@ -986,7 +986,7 @@
 
     "react-dom": ["react-dom@19.0.0", "", { "dependencies": { "scheduler": "^0.25.0" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ=="],
 
-    "react-hook-form": ["react-hook-form@7.54.2", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg=="],
+    "react-hook-form": ["react-hook-form@7.61.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-o8S/HcCeuaAQVib36fPCgOLaaQN/v7Anj8zlYjcLMcz+4FnNfMsoDAEvVCefLb3KDnS43wq3pwcifehhkwowuQ=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19",
-        "react-hook-form": "^7.0.0",
+        "react-hook-form": ">=7.55.0 <8.0.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17 || ^18 || ^19",
-    "react-hook-form": ">=7.55.0 <8.0.0"
+    "react-hook-form": "^7.55.0"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^8.6.12",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17 || ^18 || ^19",
-    "react-hook-form": "^7.0.0"
+    "react-hook-form": ">=7.55.0 <8.0.0"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^8.6.12",

--- a/src/LensesStorage.ts
+++ b/src/LensesStorage.ts
@@ -19,9 +19,12 @@ export class LensesStorage<T extends FieldValues> {
 
   constructor(control: Control<T>) {
     this.cache = new Map();
-
-    control?._subjects?.values?.subscribe?.({
-      next: () => {
+    control._subscribe({
+      formState: {
+        values: true,
+      },
+      exact: true,
+      callback: () => {
         control._names.unMount.forEach((name) => {
           this.delete(name);
         });

--- a/src/useLens.ts
+++ b/src/useLens.ts
@@ -6,7 +6,7 @@ import { LensesStorage } from './LensesStorage';
 import type { Lens } from './types';
 
 export interface UseLensProps<TFieldValues extends FieldValues = FieldValues> {
-  control: Control<TFieldValues>;
+  control: Control<TFieldValues, any, any>;
 }
 
 /**


### PR DESCRIPTION
1. `subjects.values` is replaced to subscribing `formState` (react-hook-form/react-hook-form#11522)
2. `Control` type now has `TTransformedValues` generic parameters (react-hook-form/react-hook-form#12638)

