### PR TITLE
Use bun to publish next version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Bun
-      uses: oven-sh/setup-bun@v1
+      uses: oven-sh/setup-bun@v2
       with:
         bun-version-file: '.bun-version'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,8 @@ jobs:
       - name: Publish Next Version
         run: |
           bunx semantic-release \
-            --branches '[{"name": "*", "channel": "next", "prerelease": true}]' \
+            --no-ci \
+            --branches '[{"name": "${{ github.head_ref }}", "channel": "next", "prerelease": true}]' \
             --plugins '@semantic-release/commit-analyzer,@semantic-release/npm'
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    types: [labeled]
     paths-ignore:
       - '.gitignore'
       - '.npmignore'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,19 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup environment
         uses: ./.github/actions/setup
 
       - name: Build
         run: bun run build
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Create semantic-release config
         run: |
@@ -75,24 +81,13 @@ jobs:
           }
           EOF
 
-      - name: Debug config
-        run: cat .releaserc.json
-
-      - name: Debug git info
-        run: |
-          echo "Current branch: $(git branch --show-current)"
-          echo "Git status:"
-          git status
-          echo "Git log (last commit):"
-          git log -1 --oneline
-
       - name: Publish Next Version
         run: |
           # Force git to think we're on the actual branch
           git checkout -b ${{ github.head_ref }} || git checkout ${{ github.head_ref }}
           echo "Current branch after checkout: $(git branch --show-current)"
 
-          # Create a config with main + prerelease branch
+          # Create a config with main + prerelease branch (no git operations)
           cat > .releaserc.json << EOF
           {
             "branches": [
@@ -101,8 +96,11 @@ jobs:
             ],
             "plugins": [
               "@semantic-release/commit-analyzer",
-              "@semantic-release/npm"
-            ]
+              ["@semantic-release/npm", {
+                "tarballDir": "dist/"
+              }]
+            ],
+            "repositoryUrl": false
           }
           EOF
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
           git checkout -b ${{ github.head_ref }} || git checkout ${{ github.head_ref }}
           echo "Current branch after checkout: $(git branch --show-current)"
 
-          # Create a config with main + prerelease branch (no git operations)
+          # Create a config with main + prerelease branch (npm only, no git operations)
           cat > .releaserc.json << EOF
           {
             "branches": [
@@ -100,8 +100,7 @@ jobs:
               ["@semantic-release/npm", {
                 "tarballDir": "dist/"
               }]
-            ],
-            "repositoryUrl": false
+            ]
           }
           EOF
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Setup environment
         uses: ./.github/actions/setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,57 +61,24 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Configure Git
+      - name: Generate canary version and publish
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          # Generate unique canary version
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          CURRENT_DATE=$(date +%Y%m%d)
+          SHORT_COMMIT=$(git rev-parse --short HEAD)
+          CANARY_VERSION="0.0.0-canary-${PR_NUMBER}-${CURRENT_DATE}-${SHORT_COMMIT}"
 
-      - name: Create semantic-release config
-        run: |
-          cat > .releaserc.json << 'EOF'
-          {
-            "branches": [
-              {"name": "main"},
-              {"name": "${{ github.head_ref }}", "channel": "next", "prerelease": true}
-            ],
-            "plugins": [
-              "@semantic-release/commit-analyzer",
-              "@semantic-release/npm"
-            ]
-          }
-          EOF
+          echo "Publishing canary version: ${CANARY_VERSION}"
 
-      - name: Publish Next Version
-        run: |
-          # Force git to think we're on the actual branch
-          git checkout -b ${{ github.head_ref }} || git checkout ${{ github.head_ref }}
-          echo "Current branch after checkout: $(git branch --show-current)"
+          # Update package.json version using bun
+          bun --bun -e "
+            const pkg = JSON.parse(require('fs').readFileSync('./package.json', 'utf8'));
+            pkg.version = '${CANARY_VERSION}';
+            require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
 
-          # Create a config with main + prerelease branch (npm only, no git operations)
-          cat > .releaserc.json << EOF
-          {
-            "branches": [
-              "main",
-              {"name": "${{ github.head_ref }}", "channel": "next", "prerelease": true}
-            ],
-            "plugins": [
-              "@semantic-release/commit-analyzer",
-              ["@semantic-release/npm", {
-                "tarballDir": "dist/"
-              }]
-            ]
-          }
-          EOF
-
-          echo "Updated config:"
-          cat .releaserc.json
-
-          # Unset CI environment variables that might interfere
-          unset GITHUB_ACTIONS
-          unset CI
-
-          bunx semantic-release --no-ci --debug
+          # Publish with bun
+          bun publish --tag next --access public
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
             require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
 
-          # Publish with bun
+          # Publish with bun (uses NPM_CONFIG_TOKEN env var automatically)
           bun publish --tag next --access public
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,3 +96,6 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}'
+          GITHUB_REF: refs/heads/${{ github.head_ref }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_BASE_REF: ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,10 +92,11 @@ jobs:
           git checkout -b ${{ github.head_ref }} || git checkout ${{ github.head_ref }}
           echo "Current branch after checkout: $(git branch --show-current)"
 
-          # Create a simple config that only targets this branch
+          # Create a config with main + prerelease branch
           cat > .releaserc.json << EOF
           {
             "branches": [
+              "main",
               {"name": "${{ github.head_ref }}", "channel": "next", "prerelease": true}
             ],
             "plugins": [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,23 @@ jobs:
       - name: Build
         run: bun run build
 
+      - name: Debug branch info
+        run: |
+          echo "github.head_ref: ${{ github.head_ref }}"
+          echo "github.ref: ${{ github.ref }}"
+          echo "GITHUB_REF: $GITHUB_REF"
+
       - name: Publish Next Version
         run: |
+          BRANCH_NAME="${{ github.head_ref }}"
+          if [ -z "$BRANCH_NAME" ]; then
+            BRANCH_NAME="types-rework"
+          fi
+          echo "Using branch: $BRANCH_NAME"
+
           bunx semantic-release \
             --no-ci \
-            --branches '[{"name": "${{ github.head_ref }}", "channel": "next", "prerelease": true}]' \
+            --branches "[{\"name\": \"main\"}, {\"name\": \"$BRANCH_NAME\", \"channel\": \"next\", \"prerelease\": true}]" \
             --plugins '@semantic-release/commit-analyzer,@semantic-release/npm'
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, labeled]
     paths-ignore:
       - '.gitignore'
       - '.npmignore'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,21 @@ jobs:
       - name: Debug config
         run: cat .releaserc.json
 
+      - name: Debug git info
+        run: |
+          echo "Current branch: $(git branch --show-current)"
+          echo "Git status:"
+          git status
+          echo "Git log (last commit):"
+          git log -1 --oneline
+
       - name: Publish Next Version
-        run: bunx semantic-release --no-ci
+        run: |
+          # Force git to think we're on the actual branch
+          git checkout -b ${{ github.head_ref }} || git checkout ${{ github.head_ref }}
+          echo "Current branch after checkout: $(git branch --show-current)"
+
+          bunx semantic-release --no-ci
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,10 +92,27 @@ jobs:
           git checkout -b ${{ github.head_ref }} || git checkout ${{ github.head_ref }}
           echo "Current branch after checkout: $(git branch --show-current)"
 
-          bunx semantic-release --no-ci
+          # Create a simple config that only targets this branch
+          cat > .releaserc.json << EOF
+          {
+            "branches": [
+              {"name": "${{ github.head_ref }}", "channel": "next", "prerelease": true}
+            ],
+            "plugins": [
+              "@semantic-release/commit-analyzer",
+              "@semantic-release/npm"
+            ]
+          }
+          EOF
+
+          echo "Updated config:"
+          cat .releaserc.json
+
+          # Unset CI environment variables that might interfere
+          unset GITHUB_ACTIONS
+          unset CI
+
+          bunx semantic-release --no-ci --debug
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}'
-          GITHUB_REF: refs/heads/${{ github.head_ref }}
-          GITHUB_HEAD_REF: ${{ github.head_ref }}
-          GITHUB_BASE_REF: ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 
   publish-next:
     name: Publish Next Version
-    if: github.repository == 'react-hook-form/lenses' && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'publish-next')
+    if: github.repository == 'react-hook-form/lenses' && github.event_name == 'pull_request' && contains(toJson(github.event.pull_request.labels), 'publish-next')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Publish Next Version
         run: |
           bunx semantic-release \
-            --branches '{"name": "*", "channel": "next", "prerelease": true}' \
+            --branches '[{"name": "*", "channel": "next", "prerelease": true}]' \
             --plugins '@semantic-release/commit-analyzer,@semantic-release/npm'
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,24 +59,26 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Debug branch info
+      - name: Create semantic-release config
         run: |
-          echo "github.head_ref: ${{ github.head_ref }}"
-          echo "github.ref: ${{ github.ref }}"
-          echo "GITHUB_REF: $GITHUB_REF"
+          cat > .releaserc.json << 'EOF'
+          {
+            "branches": [
+              {"name": "main"},
+              {"name": "${{ github.head_ref }}", "channel": "next", "prerelease": true}
+            ],
+            "plugins": [
+              "@semantic-release/commit-analyzer",
+              "@semantic-release/npm"
+            ]
+          }
+          EOF
+
+      - name: Debug config
+        run: cat .releaserc.json
 
       - name: Publish Next Version
-        run: |
-          BRANCH_NAME="${{ github.head_ref }}"
-          if [ -z "$BRANCH_NAME" ]; then
-            BRANCH_NAME="types-rework"
-          fi
-          echo "Using branch: $BRANCH_NAME"
-
-          bunx semantic-release \
-            --no-ci \
-            --branches "[{\"name\": \"main\"}, {\"name\": \"$BRANCH_NAME\", \"channel\": \"next\", \"prerelease\": true}]" \
-            --plugins '@semantic-release/commit-analyzer,@semantic-release/npm'
+        run: bunx semantic-release --no-ci
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [labeled]
     paths-ignore:
       - '.gitignore'
       - '.npmignore'
@@ -40,7 +41,7 @@ jobs:
 
   publish-next:
     name: Publish Next Version
-    if: github.repository == 'react-hook-form/lenses' && github.event_name == 'pull_request' && contains(toJson(github.event.pull_request.labels), 'publish-next')
+    if: github.repository == 'react-hook-form/lenses' && github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'publish-next'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/src/types/Interop.ts
+++ b/src/types/Interop.ts
@@ -44,29 +44,6 @@ export interface LensInteropFunction<T extends FieldValues, Name, R> {
 
 export interface LensInterop<T> {
   /**
-   * This method allows you to use `control` and `name` properties from react-hook-form in a callback.
-   *
-   * @example
-   * ```tsx
-   * function App() {
-   *   const { control, handleSubmit } = useForm<{
-   *     firstName: string;
-   *   }>();
-   *
-   *   const lens = useLens({ control });
-   *
-   *   return (
-   *     <form onSubmit={handleSubmit(console.log)}>
-   *       <input {...lens.focus('firstName').interop((ctrl, name) => ctrl.register(name))} />
-   *       <input type="submit" />
-   *     </form>
-   *   );
-   * }
-   * ```
-   */
-  interop<R>(callback: LensInteropFunction<HookFormControlShim<T>, ShimKeyName, R>): R;
-
-  /**
    * This method returns `name` and `control` properties from react-hook-form.
    *
    * @example
@@ -89,4 +66,27 @@ export interface LensInterop<T> {
    * ```
    */
   interop(): LensInteropBinding<HookFormControlShim<T>, ShimKeyName>;
+
+  /**
+   * This method allows you to use `control` and `name` properties from react-hook-form in a callback.
+   *
+   * @example
+   * ```tsx
+   * function App() {
+   *   const { control, handleSubmit } = useForm<{
+   *     firstName: string;
+   *   }>();
+   *
+   *   const lens = useLens({ control });
+   *
+   *   return (
+   *     <form onSubmit={handleSubmit(console.log)}>
+   *       <input {...lens.focus('firstName').interop((ctrl, name) => ctrl.register(name))} />
+   *       <input type="submit" />
+   *     </form>
+   *   );
+   * }
+   * ```
+   */
+  interop<R>(callback: LensInteropFunction<HookFormControlShim<T>, ShimKeyName, R>): R;
 }

--- a/src/types/Interop.ts
+++ b/src/types/Interop.ts
@@ -44,6 +44,29 @@ export interface LensInteropFunction<T extends FieldValues, Name, R> {
 
 export interface LensInterop<T> {
   /**
+   * This method allows you to use `control` and `name` properties from react-hook-form in a callback.
+   *
+   * @example
+   * ```tsx
+   * function App() {
+   *   const { control, handleSubmit } = useForm<{
+   *     firstName: string;
+   *   }>();
+   *
+   *   const lens = useLens({ control });
+   *
+   *   return (
+   *     <form onSubmit={handleSubmit(console.log)}>
+   *       <input {...lens.focus('firstName').interop((ctrl, name) => ctrl.register(name))} />
+   *       <input type="submit" />
+   *     </form>
+   *   );
+   * }
+   * ```
+   */
+  interop<R>(callback: LensInteropFunction<HookFormControlShim<T>, ShimKeyName, R>): R;
+
+  /**
    * This method returns `name` and `control` properties from react-hook-form.
    *
    * @example
@@ -66,27 +89,4 @@ export interface LensInterop<T> {
    * ```
    */
   interop(): LensInteropBinding<HookFormControlShim<T>, ShimKeyName>;
-
-  /**
-   * This method allows you to use `control` and `name` properties from react-hook-form in a callback.
-   *
-   * @example
-   * ```tsx
-   * function App() {
-   *   const { control, handleSubmit } = useForm<{
-   *     firstName: string;
-   *   }>();
-   *
-   *   const lens = useLens({ control });
-   *
-   *   return (
-   *     <form onSubmit={handleSubmit(console.log)}>
-   *       <input {...lens.focus('firstName').interop((ctrl, name) => ctrl.register(name))} />
-   *       <input type="submit" />
-   *     </form>
-   *   );
-   * }
-   * ```
-   */
-  interop<R>(callback: LensInteropFunction<HookFormControlShim<T>, ShimKeyName, R>): R;
 }


### PR DESCRIPTION
I used semantic release inside https://github.com/react-hook-form/lenses/pull/36
But looks like it doesn't support publishing from random branches https://github.com/react-hook-form/lenses/actions/runs/16757679960/job/47444502567
```
[6:06:39 PM] [semantic-release] › ℹ  This test run was triggered on the branch refs/pull/35/merge, while semantic-release is configured to only publish from main, types-rework, therefore a new version won’t be published.
```

So i used bun to publish to next version