### PR TITLE
Support BrowserNativeObject types in Lens

### DIFF
--- a/src/types/Lens.ts
+++ b/src/types/Lens.ts
@@ -1,4 +1,4 @@
-import type { FieldValues } from 'react-hook-form';
+import type { BrowserNativeObject, FieldValues } from 'react-hook-form';
 
 import type { ArrayLens } from './ArrayLens';
 import type { HookFormControlShim } from './Interop';
@@ -47,8 +47,9 @@ export type LensesDictionary<T> = {
 
 export type LensesGetter<T> = LensesDictionary<T> | Lens<T>;
 
-export type UnwrapLens<T> =
-  T extends HookFormControlShim<any>
+export type UnwrapLens<T> = T extends BrowserNativeObject
+  ? T
+  : T extends HookFormControlShim<any>
     ? unknown
     : T extends (infer U)[]
       ? UnwrapLens<U>[]

--- a/tests/object-reflect.test.ts
+++ b/tests/object-reflect.test.ts
@@ -61,7 +61,6 @@ test('reflect can add props from another lens', () => {
   expectTypeOf(form1.current.reflect((l) => ({ c: l.a, d: form2.current.focus('b') }))).toEqualTypeOf<Lens<{ c: string; d: number }>>();
 });
 
-
 test('reflect return an object contains Date, File, FileList', () => {
   const { result } = renderHook(() => {
     const form = useForm<{ date: Date; file: File; fileList: FileList }>();

--- a/tests/object-reflect.test.ts
+++ b/tests/object-reflect.test.ts
@@ -60,3 +60,32 @@ test('reflect can add props from another lens', () => {
 
   expectTypeOf(form1.current.reflect((l) => ({ c: l.a, d: form2.current.focus('b') }))).toEqualTypeOf<Lens<{ c: string; d: number }>>();
 });
+
+
+test('reflex return an object contains Date, File, FileList', () => {
+  const { result } = renderHook(() => {
+    const form = useForm<{ date: Date; file: File; fileList: FileList }>();
+    const lens = useLens({ control: form.control });
+    return lens;
+  });
+
+  const reflectedLens = result.current.reflect((dic) => {
+    expectTypeOf(dic.date).toEqualTypeOf<Lens<Date>>();
+    expectTypeOf(dic.file).toEqualTypeOf<Lens<File>>();
+    expectTypeOf(dic.fileList).toEqualTypeOf<Lens<FileList>>();
+
+    return {
+      date: dic.date,
+      file: dic.file,
+      fileList: dic.fileList,
+    };
+  });
+
+  expectTypeOf(reflectedLens).toEqualTypeOf<
+    Lens<{
+      date: Date;
+      file: File;
+      fileList: FileList;
+    }>
+  >();
+});

--- a/tests/object-reflect.test.ts
+++ b/tests/object-reflect.test.ts
@@ -62,7 +62,7 @@ test('reflect can add props from another lens', () => {
 });
 
 
-test('reflex return an object contains Date, File, FileList', () => {
+test('reflect return an object contains Date, File, FileList', () => {
   const { result } = renderHook(() => {
     const form = useForm<{ date: Date; file: File; fileList: FileList }>();
     const lens = useLens({ control: form.control });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM"],
     "module": "ESNext",
     "rootDir": ".",
     "baseUrl": ".",


### PR DESCRIPTION
Closes https://github.com/react-hook-form/lenses/issues/40

Updated UnwrapLens type to handle BrowserNativeObject, allowing proper typing for Date, File, and FileList. Added tests to verify Lens behavior with these types. Updated tsconfig to include DOM lib for type support.