### PR TITLE
feat: support nested object in reflect

### DIFF
--- a/src/types/Lens.ts
+++ b/src/types/Lens.ts
@@ -45,7 +45,10 @@ export type LensesDictionary<T> = {
   [P in keyof T]: Lens<T[P]>;
 };
 
-export type LensesGetter<T> = LensesDictionary<T> | Lens<T>;
+export type RecursiveLensesDictionary<T> = {
+  [P in keyof T]: Lens<T[P]> | RecursiveLensesDictionary<T[P]>;
+}
+export type LensesGetter<T> = RecursiveLensesDictionary<T> | Lens<T>;
 
 export type UnwrapLens<T> = T extends BrowserNativeObject
   ? T

--- a/src/types/Lens.ts
+++ b/src/types/Lens.ts
@@ -47,7 +47,8 @@ export type LensesDictionary<T> = {
 
 export type RecursiveLensesDictionary<T> = {
   [P in keyof T]: Lens<T[P]> | RecursiveLensesDictionary<T[P]>;
-}
+};
+
 export type LensesGetter<T> = RecursiveLensesDictionary<T> | Lens<T>;
 
 export type UnwrapLens<T> = T extends BrowserNativeObject

--- a/tests/object-reflect.test.ts
+++ b/tests/object-reflect.test.ts
@@ -335,7 +335,7 @@ test('nested object reflect does not append paths', () => {
   expect(reflected.focus('x.y').interop().name).toBe('a.b.c');
 });
 
-test('multiple nested reflect calls preserve correct path', () => {
+test('reflect with nested object preserve correct path', () => {
   const { result } = renderHook(() => {
     const form = useForm<{ values: { a: string } }>();
     const lens = useLens({ control: form.control });

--- a/tests/object-reflect.test.ts
+++ b/tests/object-reflect.test.ts
@@ -268,3 +268,69 @@ test('reflected lens with nested objects resolves correct paths', () => {
   expect(reflected.focus('password.password_confirm').interop().name).toBe('password.passwordConfirm');
   expect(reflected.focus('nest2.names.name').interop().name).toBe('usernameNest.name');
 });
+
+test('reflected lenses without focus do not append paths', () => {
+  type Input = {
+    a: {
+      b: {
+        c: string;
+      };
+    };
+  };
+
+  type Result = {
+    x: {
+      y: string;
+    };
+  };
+
+  const { result } = renderHook(() => {
+    const form = useForm<Input>();
+    const lens = useLens({ control: form.control });
+    return lens;
+  });
+
+  const lens = result.current;
+
+  const reflected: Lens<Result> = lens.reflect((_, l) => ({
+    x: l.reflect((_, l2) => {
+      return {
+        y: l2.focus('a.b.c'),
+      };
+    }),
+  }));
+
+  expect(reflected.focus('x.y').interop().name).toBe('a.b.c');
+});
+
+test('nested object reflect does not append paths', () => {
+  type Input = {
+    a: {
+      b: {
+        c: string;
+      };
+    };
+  };
+
+  type Result = {
+    x: {
+      y: string;
+    };
+  };
+
+  const { result } = renderHook(() => {
+    const form = useForm<Input>();
+    const lens = useLens({ control: form.control });
+    return lens;
+  });
+
+  const lens = result.current;
+
+  const reflected: Lens<Result> = lens.reflect((_, l) => ({
+    x: {
+      y: l.focus('a.b.c'),
+    },
+  }));
+
+  expect(reflected.focus('x.y').interop().name).toBe('a.b.c');
+});

--- a/tests/object-reflect.test.ts
+++ b/tests/object-reflect.test.ts
@@ -334,3 +334,27 @@ test('nested object reflect does not append paths', () => {
 
   expect(reflected.focus('x.y').interop().name).toBe('a.b.c');
 });
+
+test('multiple nested reflect calls preserve correct path', () => {
+  const { result } = renderHook(() => {
+    const form = useForm<{ values: { a: string } }>();
+    const lens = useLens({ control: form.control });
+    return lens;
+  });
+
+  const lens = result.current;
+
+  const reflected = lens.focus('values').reflect((_, l) => {
+    return {
+      nested: {
+        deeper: {
+          field: l.focus('a'),
+        },
+      },
+    };
+  });
+
+  expect(reflected.focus('nested').interop().name).toBe('values');
+  expect(reflected.focus('nested.deeper').interop().name).toBe('values');
+  expect(reflected.focus('nested.deeper.field').interop().name).toBe('values.a');
+});


### PR DESCRIPTION
Add support for returning nested objects from `reflect` by wrapping non-lenses with `reflect` before resolving within `focus`.

Nested object properties are treated as a `lens.reflect` without appending any path segments.

Closes #45 