### PR TITLE
Assign TFieldsValues to fieldsValues instead of transformedValues

### DIFF
--- a/src/useLens.ts
+++ b/src/useLens.ts
@@ -6,7 +6,7 @@ import { LensesStorage } from './LensesStorage';
 import type { Lens } from './types';
 
 export interface UseLensProps<TFieldValues extends FieldValues = FieldValues> {
-  control: Control<any, any, TFieldValues>;
+  control: Control<TFieldValues, any, any>;
 }
 
 /**


### PR DESCRIPTION
Resolves #39

Support for the `TransformedValues` type was raised in issue #34. The example in that issue showed that when using Zod together with @hookform/resolvers/zod, there is no type support when the input and output differ.

This was addressed in commit fc6c0a4cccd13ffaf781f799522dc0aa1f165acc by passing `TransformedValues` to the generic of `useLens` instead of the control’s `FieldValues`. However, a lens only deals with the input side of the form and does not concern itself with the submission type after resolution, so this change is inappropriate.

Suppose we have a Zod schema like the following.

```ts
const FormSchema = z.object({
  a: z.string().transform(value => Number.parseInt(value, 10)),
});
type FormInput = z.input<typeof FormSchema>;
type FormOutput = z.output<typeof FormSchema>; // Same as z.infer

// input: FormInput, output: FormOutput
const formMethods = useForm({ resolver: zodResolver(FormSchema) });
```

In this case, the form’s input type is `FormInput`, and the submitted data type should be `FormOutput`.